### PR TITLE
Montaje de directorios remotos vía CIFS/SMB

### DIFF
--- a/instalar
+++ b/instalar
@@ -17,9 +17,13 @@ HD_ROOT=20480
 LOCAL_MP='/tmp/pxe'
 REMOTE_MP='/pxe'
 IMAGE_DIR="$LOCAL_MP/img"
-NFSMOUNT=`/etc/init.d/nfsmount status | awk -F: '{print $2}' | sed 's/ //g'`
+
 START_TIME=0
 END_TIME=0
+
+get_nfsmount_status() {
+/etc/init.d/nfsmount status | awk -F: '{print $2}' | sed 's/ //g'
+}
 
 function pause(){
   read -p "$*"
@@ -74,7 +78,7 @@ function img_install(){
 echo "* Instalación de la imagen *"
 echo "Iniciando instalación de imagen"
 
-if [ $NFSMOUNT != 'started' ]; then
+if [ $(get_nfsmount_status) != 'started' ]; then
     echo "Servicio NFS desactivado, activando..."
     /etc/init.d/nfsmount start &> /dev/null
 fi
@@ -108,7 +112,7 @@ fsarchiver restfs $IMAGE_DIR/${IMAGES[$SELECTED]} id=0,dest="$HD"1 &> /dev/null
 fsarchiver restfs $IMAGE_DIR/${IMAGES[$SELECTED]} id=1,dest="$HD"3 &> /dev/null
 umount $IMAGE_DIR &> /dev/null
 
-if [ $NFSMOUNT = 'started' ]; then
+if [ $(get_nfsmount_status) = 'started' ]; then
     echo "Servicio NFS activado, desactivando..."
     /etc/init.d/nfsmount start &> /dev/null
 fi

--- a/instalar
+++ b/instalar
@@ -10,6 +10,7 @@
 
 #A copy of the GNU General Public License is available as /usr/share/common-licenses/GPL in the Debian GNU/Linux distribution or on the World Wide Web at the GNU website You can also obtain it by writing to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
 
+REMOTE_TYPE=${REMOTE_TYPE:-'NFS'}  # NFS, CIFS
 SERVER=10.10.20.3
 HD='/dev/sda'
 HD_SWAP=4096
@@ -78,13 +79,19 @@ function img_install(){
 echo "* Instalación de la imagen *"
 echo "Iniciando instalación de imagen"
 
-if ! is_nfsmount_started; then
+if [ "$REMOTE_TYPE" = 'NFS' ] && ! is_nfsmount_started; then
     echo "Servicio NFS desactivado, activando..."
     /etc/init.d/nfsmount start &> /dev/null
 fi
 
 mkdir $LOCAL_MP
-mount -o nolock $SERVER:$REMOTE_MP $LOCAL_MP &> /dev/null
+case "$REMOTE_TYPE" in
+    (NFS) mount -t nfs -o nolock "$SERVER:$REMOTE_MP" "$LOCAL_MP" &> /dev/null
+          ;;
+    (CIFS) mount -t cifs -o ro,guest "//$SERVER/$REMOTE_MP" "$LOCAL_MP" &> /dev/null
+           ;;
+    # (*) = local
+esac
 cd $IMAGE_DIR
 IMAGES=($(ls -f ./*.fsa))
 cd - &> /dev/null
@@ -112,7 +119,7 @@ fsarchiver restfs $IMAGE_DIR/${IMAGES[$SELECTED]} id=0,dest="$HD"1 &> /dev/null
 fsarchiver restfs $IMAGE_DIR/${IMAGES[$SELECTED]} id=1,dest="$HD"3 &> /dev/null
 umount $IMAGE_DIR &> /dev/null
 
-if is_nfsmount_started; then
+if [ "$REMOTE_TYPE" = 'NFS' ] && is_nfsmount_started; then
     echo "Servicio NFS activado, desactivando..."
     /etc/init.d/nfsmount start &> /dev/null
 fi

--- a/instalar
+++ b/instalar
@@ -21,8 +21,8 @@ IMAGE_DIR="$LOCAL_MP/img"
 START_TIME=0
 END_TIME=0
 
-get_nfsmount_status() {
-/etc/init.d/nfsmount status | awk -F: '{print $2}' | sed 's/ //g'
+is_nfsmount_started() {
+test $(/etc/init.d/nfsmount status | awk -F: '{print $2}' | sed 's/ //g') = 'started'
 }
 
 function pause(){
@@ -78,7 +78,7 @@ function img_install(){
 echo "* Instalación de la imagen *"
 echo "Iniciando instalación de imagen"
 
-if [ $(get_nfsmount_status) != 'started' ]; then
+if ! is_nfsmount_started; then
     echo "Servicio NFS desactivado, activando..."
     /etc/init.d/nfsmount start &> /dev/null
 fi
@@ -112,7 +112,7 @@ fsarchiver restfs $IMAGE_DIR/${IMAGES[$SELECTED]} id=0,dest="$HD"1 &> /dev/null
 fsarchiver restfs $IMAGE_DIR/${IMAGES[$SELECTED]} id=1,dest="$HD"3 &> /dev/null
 umount $IMAGE_DIR &> /dev/null
 
-if [ $(get_nfsmount_status) = 'started' ]; then
+if is_nfsmount_started; then
     echo "Servicio NFS activado, desactivando..."
     /etc/init.d/nfsmount start &> /dev/null
 fi

--- a/instalar
+++ b/instalar
@@ -86,11 +86,13 @@ fi
 
 mkdir $LOCAL_MP
 case "$REMOTE_TYPE" in
-    (NFS) mount -t nfs -o nolock "$SERVER:$REMOTE_MP" "$LOCAL_MP" &> /dev/null
+    (NFS) mount -t nfs -o nolock "$SERVER:$REMOTE_MP" "$LOCAL_MP" &> /dev/null \
+                && REMOTE_MOUNTED=yes
           ;;
-    (CIFS) mount -t cifs -o ro,guest "//$SERVER/$REMOTE_MP" "$LOCAL_MP" &> /dev/null
+    (CIFS) mount -t cifs -o ro,guest "//$SERVER/$REMOTE_MP" "$LOCAL_MP" &> /dev/null \
+                 && REMOTE_MOUNTED=yes
            ;;
-    # (*) = local
+    (*) REMOTE_MOUNTED=no  # local
 esac
 cd $IMAGE_DIR
 IMAGES=($(ls -f ./*.fsa))
@@ -117,7 +119,9 @@ La operación puede durar aproximadamente 5 minutos."
 
 fsarchiver restfs $IMAGE_DIR/${IMAGES[$SELECTED]} id=0,dest="$HD"1 &> /dev/null
 fsarchiver restfs $IMAGE_DIR/${IMAGES[$SELECTED]} id=1,dest="$HD"3 &> /dev/null
-umount $IMAGE_DIR &> /dev/null
+if [ $REMOTE_MOUNTED = yes ]; then
+    umount "$LOCAL_MP" &> /dev/null
+fi
 
 if [ "$REMOTE_TYPE" = 'NFS' ] && is_nfsmount_started; then
     echo "Servicio NFS activado, desactivando..."

--- a/instalar
+++ b/instalar
@@ -89,7 +89,7 @@ case "$REMOTE_TYPE" in
     (NFS) mount -t nfs -o nolock "$SERVER:$REMOTE_MP" "$LOCAL_MP" &> /dev/null \
                 && REMOTE_MOUNTED=yes
           ;;
-    (CIFS) mount -t cifs -o ro,guest "//$SERVER/$REMOTE_MP" "$LOCAL_MP" &> /dev/null \
+    (CIFS) mount -t cifs -o ro,guest "//$SERVER$REMOTE_MP" "$LOCAL_MP" &> /dev/null \
                  && REMOTE_MOUNTED=yes
            ;;
     (*) REMOTE_MOUNTED=no  # local


### PR DESCRIPTION
Este cambio permite el uso de directorios remotos servidos por CIFS/SMB (Windows/Samba) además del habitual NFS. Éste último se usa por defecto, a no ser que se especifique la variable de entorno ``REMOTE_TYPE``, por ejemplo:

    # env REMOTE_TYPE=CIFS instalar

También corrije el desmontaje del directorio local.