### PR TITLE
Autoinstalación desatendida

### DIFF
--- a/instalar
+++ b/instalar
@@ -10,6 +10,7 @@
 
 #A copy of the GNU General Public License is available as /usr/share/common-licenses/GPL in the Debian GNU/Linux distribution or on the World Wide Web at the GNU website You can also obtain it by writing to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
 
+ASK=${ASK:-yes}  # "yes" o "no"
 SERVER=10.10.20.3
 HD='/dev/sda'
 HD_SWAP=4096
@@ -28,7 +29,7 @@ function pause(){
 
 function init_msg(){
 START_TIME=`date +%s`
-pause "** INSTALACIÓN AUTOMÁTICA DE SSOO **
+test "$ASK" = yes && pause "** INSTALACIÓN AUTOMÁTICA DE SSOO **
 EL CONTENIDO DEL DISCO DURO SE BORRARÁ POR COMPLETO.
 
 Pulse CONTROL+C para detener la instalación.

--- a/instalar
+++ b/instalar
@@ -29,7 +29,7 @@ function pause(){
 
 function init_msg(){
 START_TIME=`date +%s`
-test "$CONFIRM" = yes && pause "** INSTALACIÓN AUTOMÁTICA DE SSOO **
+test "$CONFIRM" = no || pause "** INSTALACIÓN AUTOMÁTICA DE SSOO **
 EL CONTENIDO DEL DISCO DURO SE BORRARÁ POR COMPLETO.
 
 Pulse CONTROL+C para detener la instalación.

--- a/instalar
+++ b/instalar
@@ -17,6 +17,7 @@ HD_ROOT=20480
 LOCAL_MP='/tmp/pxe'
 REMOTE_MP='/pxe'
 IMAGE_DIR="$LOCAL_MP/img"
+IMAGE_NAME=${IMAGE_NAME:-}  # "lubuntu-i386-es", no "lubuntu-i386-es.fsa"
 NFSMOUNT=`/etc/init.d/nfsmount status | awk -F: '{print $2}' | sed 's/ //g'`
 START_TIME=0
 END_TIME=0
@@ -81,31 +82,35 @@ fi
 
 mkdir $LOCAL_MP
 mount -o nolock $SERVER:$REMOTE_MP $LOCAL_MP &> /dev/null
-cd $IMAGE_DIR
-IMAGES=($(ls -f ./*.fsa))
-cd - &> /dev/null
-IMAGE_NUM=${#IMAGES[@]}
-((LAST_POS=$IMAGE_NUM-1))
-SELECTED=100
 
-while ! [[ "${SELECTED}" =~ ^[0-9]+$ ]] || [ $SELECTED -lt 0 ] || [ $SELECTED -ge $IMAGE_NUM ]; do
-    echo
-    echo "Imagenes disponibles para su instalación:"
-    for i in `seq 0 $LAST_POS`; do
-        IMAGES[$i]=`echo ${IMAGES[$i]} | sed 's,./,,g'`
-        echo "$i) ${IMAGES[$i]}"
+if [ ! "$IMAGE_NAME" ]; then
+    cd $IMAGE_DIR
+    IMAGES=($(ls -f ./*.fsa))
+    cd - &> /dev/null
+    IMAGE_NUM=${#IMAGES[@]}
+    ((LAST_POS=$IMAGE_NUM-1))
+    SELECTED=100
+
+    while ! [[ "${SELECTED}" =~ ^[0-9]+$ ]] || [ $SELECTED -lt 0 ] || [ $SELECTED -ge $IMAGE_NUM ]; do
+        echo
+        echo "Imagenes disponibles para su instalación:"
+        for i in `seq 0 $LAST_POS`; do
+            IMAGES[$i]=`echo ${IMAGES[$i]} | sed 's,./,,g'`
+            echo "$i) ${IMAGES[$i]}"
+        done
+        echo "Introduce el número de la imagen que deseas instalar:"
+        read SELECTED
+        echo
     done
-    echo "Introduce el número de la imagen que deseas instalar:"
-    read SELECTED
-    echo
-done
+    IMAGE_NAME=${IMAGES[$SELECTED]%.fsa}
+fi
 
-echo "Has seleccionado la imagen ${IMAGES[$SELECTED]}"
+echo "Has seleccionado la imagen $IMAGE_NAME"
 echo "Comenzando la instalación de la imagen.
 La operación puede durar aproximadamente 5 minutos."
 
-fsarchiver restfs $IMAGE_DIR/${IMAGES[$SELECTED]} id=0,dest="$HD"1 &> /dev/null
-fsarchiver restfs $IMAGE_DIR/${IMAGES[$SELECTED]} id=1,dest="$HD"3 &> /dev/null
+fsarchiver restfs "$IMAGE_DIR/$IMAGE_NAME.fsa" id=0,dest="$HD"1 &> /dev/null
+fsarchiver restfs "$IMAGE_DIR/$IMAGE_NAME.fsa" id=1,dest="$HD"3 &> /dev/null
 umount $IMAGE_DIR &> /dev/null
 
 if [ $NFSMOUNT = 'started' ]; then

--- a/instalar
+++ b/instalar
@@ -10,7 +10,7 @@
 
 #A copy of the GNU General Public License is available as /usr/share/common-licenses/GPL in the Debian GNU/Linux distribution or on the World Wide Web at the GNU website You can also obtain it by writing to the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
 
-ASK=${ASK:-yes}  # "yes" o "no"
+CONFIRM=${CONFIRM:-yes}  # "yes" o "no"
 SERVER=10.10.20.3
 HD='/dev/sda'
 HD_SWAP=4096
@@ -29,7 +29,7 @@ function pause(){
 
 function init_msg(){
 START_TIME=`date +%s`
-test "$ASK" = yes && pause "** INSTALACIÓN AUTOMÁTICA DE SSOO **
+test "$CONFIRM" = yes && pause "** INSTALACIÓN AUTOMÁTICA DE SSOO **
 EL CONTENIDO DEL DISCO DURO SE BORRARÁ POR COMPLETO.
 
 Pulse CONTROL+C para detener la instalación.


### PR DESCRIPTION
Este cambio permite elegir con una variable de entorno la imagen a instalar, y no pedir confirmación para comenzar la instalación.  Con ello se puede realizar una instalación completamente desatendida.  Por ejemplo:

    # env IMAGE_NAME=lubuntu-i386-es CONFIRM=no instalar

Instala la imagen ``lubuntu-i386-es.fsa`` (no hay que incluir la extensión) y no pide confirmación para comenzar la instalación.