### PR TITLE
Usar el GRUB local para instalar el arranque

### DIFF
--- a/instalar
+++ b/instalar
@@ -117,25 +117,22 @@ fi
 function grub_install(){
 echo "* Instalación de GRUB *"
 
-echo "Montando $HD y sus particiones..."
+echo "Montando ${HD}1..."
 mkdir /tmp/root
 mount "$HD"1 /tmp/root
-mount -t proc proc /tmp/root/proc
-mount -t sysfs sys /tmp/root/sys
-mount -o bind /dev /tmp/root/dev
 
-echo "Instalando y configurando GRUB..."
-chroot /tmp/root update-grub2 &> /dev/null
-chroot /tmp/root grub-install $HD &> /dev/null
+echo "Instalando GRUB..."
+grub-install \
+     --directory=/tmp/root/usr/lib/grub/i386-pc \
+     --locale-directory=/tmp/root/usr/share/locale \
+     --boot-directory=/tmp/root/boot \
+     $HD &> /dev/null
 
 echo "Generando UUID $HD2 (swap)..."
 OLD_SWAP_UUID=`cat /tmp/root/etc/fstab | grep swap | grep 'UUID' | cut -d "=" -f 2 | cut -d " " -f 1`
 sed -i "s/$OLD_SWAP_UUID/$NEW_SWAP_UUID/g" /tmp/root/etc/fstab
 
-echo "Desmontando $HD y sus particiones"
-umount /tmp/root/dev
-umount /tmp/root/sys
-umount /tmp/root/proc
+echo "Desmontando ${HD}1"
 umount /tmp/root
 rmdir /tmp/root
 }

--- a/instalar
+++ b/instalar
@@ -124,8 +124,7 @@ mount "$HD"1 /tmp/root
 echo "Instalando GRUB..."
 grub-install \
      --directory=/tmp/root/usr/lib/grub/i386-pc \
-     --locale-directory=/tmp/root/usr/share/locale \
-     --boot-directory=/tmp/root/boot \
+     --root-directory=/tmp/root \
      $HD &> /dev/null
 
 echo "Generando UUID $HD2 (swap)..."


### PR DESCRIPTION
Esta opción es más sencilla (no hace falta preparar el entorno ``chroot``) y además funciona tanto si el sistema instalado es de 32 bits como si es de 64.

En cambio, necesita que el paquete ``grub2-common`` (para el ejecutable ``grub-install``) esté instalado en el sistema donde se ejecuta el script.