### PR TITLE
Eliminar el BOM de Unicode de la segunda línea

### DIFF
--- a/instalar
+++ b/instalar
@@ -1,5 +1,5 @@
 #!/bin/bash
-﻿
+
 #(c) 2000-2015 Reciclanet Asociación Educativa-Reciclanet Hezkuntza Elkartea www.reciclanet.org
 #Copyright
 #Licencia GPL


### PR DESCRIPTION
Hace que Bash se queje de que un comando aparentemente vacío no puede ser ejecutado.

El BOM debería ir al principio del fichero, pero eso impediría que se dectectara el «shebang» ``#!``, así que mejor eliminarlo.